### PR TITLE
Nuodb

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/conf/JDBCConfigurationImpl.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/conf/JDBCConfigurationImpl.java
@@ -213,6 +213,7 @@ public class JDBCConfigurationImpl
             "jdatastore", org.apache.openjpa.jdbc.sql.JDataStoreDictionary.class.getName(),
             "mariadb", org.apache.openjpa.jdbc.sql.MariaDBDictionary.class.getName(),
             "mysql", org.apache.openjpa.jdbc.sql.MySQLDictionary.class.getName(),
+            "nuodb",org.apache.openjpa.jdbc.sql.NuoDBDictionary.class.getName(),
             "oracle", org.apache.openjpa.jdbc.sql.OracleDictionary.class.getName(),
             "pointbase", org.apache.openjpa.jdbc.sql.PointbaseDictionary.class.getName(),
             "postgres", org.apache.openjpa.jdbc.sql.PostgresDictionary.class.getName(),

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/jdbc/kernel/TestForeignKeyCountViolation.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/jdbc/kernel/TestForeignKeyCountViolation.java
@@ -105,6 +105,10 @@ public class TestForeignKeyCountViolation extends SingleEMFTestCase {
     
     public void testFKNamefromDB()throws SQLException {
         
+        if (! _conf.getDBDictionaryInstance().supportsForeignKeys) {
+            return;
+        }
+
         EntityManager em = emf.createEntityManager();
         Table tableG = getMapping(EntityG.class).getTable();
         tableG.addForeignKey();

--- a/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jpql/functions/TestEJBQLFunction.java
+++ b/openjpa-persistence-jdbc/src/test/java/org/apache/openjpa/persistence/jpql/functions/TestEJBQLFunction.java
@@ -24,6 +24,7 @@ import javax.persistence.EntityManager;
 import org.apache.openjpa.jdbc.conf.JDBCConfiguration;
 import org.apache.openjpa.jdbc.sql.DBDictionary;
 import org.apache.openjpa.jdbc.sql.OracleDictionary;
+import org.apache.openjpa.jdbc.sql.NuoDBDictionary;
 import org.apache.openjpa.jdbc.sql.SybaseDictionary;
 import org.apache.openjpa.persistence.OpenJPAEntityManagerSPI;
 import org.apache.openjpa.persistence.common.apps.Address;
@@ -169,7 +170,7 @@ public class TestEJBQLFunction extends AbstractTestCase {
         // b10759/sql_elements005.htm#sthref511
         DBDictionary dict = ((JDBCConfiguration) getEmf().getConfiguration())
             .getDBDictionaryInstance();
-        if (dict instanceof OracleDictionary) {
+        if (dict instanceof OracleDictionary || dict instanceof NuoDBDictionary) {
             assertTrue(user.getName() == null ||
                 "".equals(user.getName()));
         } else if (dict instanceof SybaseDictionary) {

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,10 @@
         <mysql.version>5.1.12</mysql.version>
         <postgresql.version>8.4-701.jdbc3</postgresql.version>
         <nuodb.version>2.3.1</nuodb.version>
-        <openjpa.nuodb.url>jdbc:com.nuodb://linux122.lab.phx.axway.int:48004/openjpa</openjpa.nuodb.url>
+        <openjpa.nuodb.url>jdbc:com.nuodb://localhost/openjpa?schema=test&amp;isolation=read_committed</openjpa.nuodb.url>
         <openjpa.nuodb.schema>test</openjpa.nuodb.schema>
+        <openjpa.nuodb.username>dba</openjpa.nuodb.username>
+        <openjpa.nuodb.password>dba</openjpa.nuodb.password>
 
         <!-- other common versions -->
         <slf4jVersion>1.6.1</slf4jVersion>


### PR DESCRIPTION
Some more implementation and changes to NuoDBDictionary.   Changes to test some basic test to check for presence of FK. 

Some failure conditions are:

1) use of ALL and ANY in test.    These test can be rewritten to use different query. 

A < ALL(SELECT x FROM y) can be rewritten as A < (SELECT MIN(x) FROM y). 
A < ANY(SELECT x FROM y) can be rewritten as A < (SELECT MAX(x) FROM y)
A = ANY(SELECT x FROM y) can be rewritten as A IN (SELECT x FROM y)
A != ANY(SELECT x FROM y) can be rewritten as A NOT IN (SELECT x FROM y)

2) some schema changes where change is already present.   Wonder if delete on setup is working?

3) Two NuoDB bugs.

concat ("","") -> null not ''   - test changed as same happens with Oracle.   This will be fixed in NuoDB.
SELECT AVG(X)/? FROM y - yields exception but should be possible.   Fixed in NuoDB in near term.

